### PR TITLE
Change output weeks length to static 6 weeks

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ var Calendar = (function() {
     }
 
     if (opts.withStaticLength === undefined) {
-      opts.withStaticLength = true;
+      opts.withStaticLength = false;
     }
 
     // we will fill in this array

--- a/index.js
+++ b/index.js
@@ -42,6 +42,10 @@ var Calendar = (function() {
       opts.withOtherMonthDays = true;
     }
 
+    if (opts.withStaticLength === undefined) {
+      opts.withStaticLength = true;
+    }
+
     // we will fill in this array
     var weeks = [];
 
@@ -86,7 +90,19 @@ var Calendar = (function() {
         w.push(this.createDay(m));
         m.add(1, 'day');
       }
-      weeks[weeks.length-1] = w;
+      weeks[weeks.length - 1] = w;
+
+      // if 5 weeks have been constructed, add one more
+      // to keep consistency with other months with 6
+      // weeks constructed
+      if (weeks.length === 5 && opts.withStaticLength) {
+        w = []
+        while (w.length < 7) {
+          w.push(this.createDay(m));
+          m.add(1, 'day');
+        }
+        weeks.push(w);
+      }
     }
 
     return weeks;

--- a/test/test.js
+++ b/test/test.js
@@ -36,4 +36,8 @@ describe('GenericTest', function() {
     assert.equal(cal[4][6].date, 4)
   });
 
+  it('should have 6 weeks of data', function () {
+    assert.equal(cal.length, 6)
+  });
+
 });

--- a/test/test.js
+++ b/test/test.js
@@ -37,7 +37,8 @@ describe('GenericTest', function() {
   });
 
   it('should have 6 weeks of data', function () {
-    assert.equal(cal.length, 6)
+    var cal2 = calendar.generate({ withStaticLength: true });
+    assert.equal(cal2.length, 6)
   });
 
 });


### PR DESCRIPTION
Hi @sjlu!

I'm currently working on a ui calendar using this package and wanted to have a static number of calendar rows independent of month, similar to Google calendar's mini-calendar

What does this do:
* Unless a flag is passed in to not keep consistent number of weeks, pad the 6th week if needed
* Add tests to test this


**Google Calendar** (notice the extra row)
<img width="265" alt="image 2018-03-19 at 2 16 02 pm" src="https://user-images.githubusercontent.com/7256628/37617127-2025ec2e-2b80-11e8-8cee-ce08403c5bc4.png">
